### PR TITLE
Update pod files for redirector lambda

### DIFF
--- a/pods/redirector.metadata.yml
+++ b/pods/redirector.metadata.yml
@@ -1,0 +1,1 @@
+pod_type: "task"

--- a/pods/redirector.yml
+++ b/pods/redirector.yml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  redirector:
+    image: rabblerouser/redirector
+    build: "git@github.com:rabblerouser/redirector.git"
+    ports:
+      - "3004:3004"
+    environment:
+      PORT: 3004
+    command: yarn dev

--- a/pods/redirector.yml
+++ b/pods/redirector.yml
@@ -2,9 +2,4 @@ version: "2"
 services:
   redirector:
     image: rabblerouser/redirector
-    build: "git@github.com:rabblerouser/redirector.git"
-    ports:
-      - "3004:3004"
-    environment:
-      PORT: 3004
-    command: yarn dev
+    build: "git@github.com:natyoung/redirector.git#:lambda"


### PR DESCRIPTION
This is to allow cage to use redirector as a task/lambda function and is dependent upon the merging of https://github.com/rabblerouser/redirector/pull/10